### PR TITLE
Fix null config in ConfigManager

### DIFF
--- a/Audio Controller/ConfigManager.cs
+++ b/Audio Controller/ConfigManager.cs
@@ -30,7 +30,12 @@ namespace Audio_Controller.Audio_Controller
             catch (Exception ex)
             {
                 Console.WriteLine($"Fehler beim Laden der Konfiguration: {ex.Message}");
-                return null;
+                // Stelle sicher, dass das Programm mit einer leeren Konfiguration fortfahren kann
+                return new AppConfig
+                {
+                    ComPort = null,
+                    ChannelDeviceMap = new Dictionary<int, string>()
+                };
             }
         }
 


### PR DESCRIPTION
## Summary
- prevent null configuration from crashing the program

## Testing
- `msbuild "Audio Controller.sln" /t:Build /p:Configuration=Release` *(fails: command not found)*
- `dotnet build 'Audio Controller.sln' --configuration Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862427055a08322bf3503e0e2a18632