### PR TITLE
Implement config persistence, console mode, and more

### DIFF
--- a/Audio Controller.csproj
+++ b/Audio Controller.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Audio Controller\AppConfig.cs" />
     <Compile Include="Audio Controller\ConfigManager.cs" />
     <Compile Include="Audio Controller\ConsoleUpdater.cs" />
+    <Compile Include="Audio Controller\ConsoleProgram.cs" />
     <Compile Include="Audio Controller\DataProcessor.cs" />
     <Compile Include="Audio Controller\MixerIdentifiers.cs" />
     <Compile Include="Audio Controller\MainForm.cs" />

--- a/Audio Controller/AppConfig.cs
+++ b/Audio Controller/AppConfig.cs
@@ -7,12 +7,16 @@ namespace Audio_Controller.Audio_Controller
     {
         public string ComPort { get; set; } // Der ausgewählte COM-Port
         public Dictionary<int, string> ChannelDeviceMap { get; set; } // Zuordnung von Kanälen zu Geräten (FriendlyName)
+        public int BufferSize { get; set; } = 5; // Glättung
+        public int DeadZone { get; set; } = 5;  // Dead-Zone
 
         // Konstruktor mit Standardwerten
         public AppConfig()
         {
             ComPort = null;
             ChannelDeviceMap = new Dictionary<int, string>();
+            BufferSize = 5;
+            DeadZone = 5;
         }
     }
 }

--- a/Audio Controller/ConsoleProgram.cs
+++ b/Audio Controller/ConsoleProgram.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using NAudio.CoreAudioApi;
+using Audio_Controller.Audio_Controller;
+
+namespace Audio_Controller
+{
+    public static class ConsoleProgram
+    {
+        public static void Run(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                Console.WriteLine("Usage: <port|auto> <channels> [device names...]");
+                return;
+            }
+
+            string port = args[0];
+            if (string.Equals(port, "auto", StringComparison.OrdinalIgnoreCase))
+            {
+                port = MixerIdentifier.FindDeviceByMessage("HELLO_MIXER", "MIXER_READY");
+                if (string.IsNullOrEmpty(port))
+                {
+                    Console.WriteLine("Mixer not found.");
+                    return;
+                }
+            }
+
+            if (!int.TryParse(args[1], out int channelCount))
+            {
+                Console.WriteLine("Invalid channel count.");
+                return;
+            }
+
+            var volumeController = new VolumeController();
+            var deviceMap = new Dictionary<int, MMDevice>();
+            for (int i = 0; i < channelCount && i + 2 < args.Length; i++)
+            {
+                var device = volumeController.GetDeviceByName(args[i + 2]);
+                if (device != null)
+                {
+                    deviceMap[i + 1] = device;
+                }
+            }
+
+            var processor = new DataProcessor(channelCount);
+            var updater = new ConsoleUpdater(channelCount);
+            var connection = new SerialConnection(port);
+            connection.DataReceived += raw =>
+            {
+                var values = processor.Process(raw);
+                for (int i = 0; i < values.Length; i++)
+                {
+                    updater.UpdateChannel(i + 1, values[i]);
+                    if (deviceMap.TryGetValue(i + 1, out var dev))
+                    {
+                        volumeController.SetVolume(dev, values[i]);
+                    }
+                }
+            };
+
+            try
+            {
+                connection.Open();
+                Console.WriteLine("Press ENTER to quit");
+                Console.ReadLine();
+            }
+            finally
+            {
+                connection.Close();
+            }
+        }
+    }
+}

--- a/Audio Controller/DataProcessor.cs
+++ b/Audio Controller/DataProcessor.cs
@@ -6,13 +6,15 @@ public class DataProcessor
 {
     private readonly int channelCount;
     private readonly Queue<int>[] valueBuffers;
-    private int deadZone = 5;
 
     public int BufferSize { get; set; } = 5; // Anzahl der Werte im gleitenden Durchschnitt
+    public int DeadZone { get; set; } = 5;   // Größe der Dead‑Zone
 
-    public DataProcessor(int channelCount)
+    public DataProcessor(int channelCount, int bufferSize = 5, int deadZone = 5)
     {
         this.channelCount = channelCount;
+        this.BufferSize = bufferSize;
+        this.DeadZone = deadZone;
         valueBuffers = new Queue<int>[channelCount];
 
         // Initialisiere den Puffer für jeden Kanal
@@ -73,7 +75,7 @@ public class DataProcessor
 
     private int ConvertToPercentageWithDeadzone(int adcValue)
     {
-        if (adcValue <= deadZone-1)
+        if (adcValue <= DeadZone - 1)
         {
             return 0; // Deadzone für 0%
         }
@@ -83,6 +85,6 @@ public class DataProcessor
         }
 
         // Wertebereich 5–1019 → 1%–99%
-        return (adcValue - deadZone) * 100 / (1023 - deadZone);
+        return (adcValue - DeadZone) * 100 / (1023 - DeadZone);
     }
 }

--- a/Audio Controller/MainForm.Designer.cs
+++ b/Audio Controller/MainForm.Designer.cs
@@ -11,8 +11,13 @@ namespace Audio_Controller
         private NumericUpDown numChannels;
         private TextBox txtComPort;
         private Button btnStart;
+        private Button btnStop;
         private Label lblChannels;
         private Label lblComPort;
+        private NumericUpDown numBufferSize;
+        private NumericUpDown numDeadZone;
+        private Label lblBufferSize;
+        private Label lblDeadZone;
 
         private void InitializeComponent()
         {
@@ -23,10 +28,17 @@ namespace Audio_Controller
             this.numChannels = new NumericUpDown();
             this.txtComPort = new TextBox();
             this.btnStart = new Button();
+            this.btnStop = new Button();
             this.lblChannels = new Label();
             this.lblComPort = new Label();
+            this.numBufferSize = new NumericUpDown();
+            this.numDeadZone = new NumericUpDown();
+            this.lblBufferSize = new Label();
+            this.lblDeadZone = new Label();
             ((System.ComponentModel.ISupportInitialize)(this.dgvMapping)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numChannels)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numBufferSize)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numDeadZone)).BeginInit();
             this.SuspendLayout();
             // 
             // dgvMapping
@@ -83,6 +95,55 @@ namespace Audio_Controller
             this.btnStart.Text = "Start";
             this.btnStart.UseVisualStyleBackColor = true;
             this.btnStart.Click += new System.EventHandler(this.btnStart_Click);
+
+            //
+            // btnStop
+            //
+            this.btnStop.Location = new System.Drawing.Point(308, 239);
+            this.btnStop.Name = "btnStop";
+            this.btnStop.Size = new System.Drawing.Size(64, 23);
+            this.btnStop.Text = "Stop";
+            this.btnStop.UseVisualStyleBackColor = true;
+            this.btnStop.Enabled = false;
+            this.btnStop.Click += new System.EventHandler(this.btnStop_Click);
+
+            //
+            // numBufferSize
+            //
+            this.numBufferSize.Location = new System.Drawing.Point(90, 239);
+            this.numBufferSize.Minimum = 1;
+            this.numBufferSize.Maximum = 20;
+            this.numBufferSize.Name = "numBufferSize";
+            this.numBufferSize.Size = new System.Drawing.Size(50, 20);
+            this.numBufferSize.Value = 5;
+
+            //
+            // numDeadZone
+            //
+            this.numDeadZone.Location = new System.Drawing.Point(242, 239);
+            this.numDeadZone.Minimum = 0;
+            this.numDeadZone.Maximum = 50;
+            this.numDeadZone.Name = "numDeadZone";
+            this.numDeadZone.Size = new System.Drawing.Size(50, 20);
+            this.numDeadZone.Value = 5;
+
+            //
+            // lblBufferSize
+            //
+            this.lblBufferSize.AutoSize = true;
+            this.lblBufferSize.Location = new System.Drawing.Point(12, 241);
+            this.lblBufferSize.Name = "lblBufferSize";
+            this.lblBufferSize.Size = new System.Drawing.Size(72, 13);
+            this.lblBufferSize.Text = "Puffergröße:";
+
+            //
+            // lblDeadZone
+            //
+            this.lblDeadZone.AutoSize = true;
+            this.lblDeadZone.Location = new System.Drawing.Point(160, 241);
+            this.lblDeadZone.Name = "lblDeadZone";
+            this.lblDeadZone.Size = new System.Drawing.Size(63, 13);
+            this.lblDeadZone.Text = "DeadZone:";
             // 
             // lblChannels
             // 
@@ -104,7 +165,12 @@ namespace Audio_Controller
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(384, 261);
+            this.ClientSize = new System.Drawing.Size(384, 271);
+            this.Controls.Add(this.btnStop);
+            this.Controls.Add(this.lblDeadZone);
+            this.Controls.Add(this.numDeadZone);
+            this.Controls.Add(this.lblBufferSize);
+            this.Controls.Add(this.numBufferSize);
             this.Controls.Add(this.lblComPort);
             this.Controls.Add(this.lblChannels);
             this.Controls.Add(this.btnStart);
@@ -115,6 +181,8 @@ namespace Audio_Controller
             this.Text = "Audio Controller";
             ((System.ComponentModel.ISupportInitialize)(this.dgvMapping)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numChannels)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numBufferSize)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numDeadZone)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
         }

--- a/Audio Controller/Program.cs
+++ b/Audio Controller/Program.cs
@@ -6,11 +6,18 @@ namespace Audio_Controller
     static class Program
     {
         [STAThread]
-        static void Main()
+        static void Main(string[] args)
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new MainForm());
+            if (args != null && args.Length > 0)
+            {
+                ConsoleProgram.Run(args);
+            }
+            else
+            {
+                Application.EnableVisualStyles();
+                Application.SetCompatibleTextRenderingDefault(false);
+                Application.Run(new MainForm());
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -15,3 +15,17 @@ After a successful build you can run the application with `mono`:
 ```bash
 mono "Audio Controller/bin/Debug/Audio Controller.exe"
 ```
+
+### Features
+
+- **Automatic COM port detection**: leave the COM port field empty and the application will search for a mixer via handshake.
+- **Stop button** to close the serial connection.
+- **Configurable smoothing** (`Puffergröße`) and `DeadZone` values.
+- **Settings persistence** for COM port, channel mapping and smoothing parameters.
+- **Console mode**: run the program with command line arguments instead of the GUI.
+
+Example for console mode:
+
+```bash
+mono "Audio Controller/bin/Debug/Audio Controller.exe" auto 2 "Speakers" "Headphones"
+```


### PR DESCRIPTION
## Summary
- persist COM port, channel mapping and smoothing settings in `config.json`
- add automatic COM port detection if the field is empty
- implement a Stop button to close the serial connection
- expose buffer size and dead-zone controls
- add a command-line console mode using `ConsoleProgram`
- document new features in README

## Testing
- `./setup.sh` *(fails: MSBUILD0004 Too many project files specified)*

------
https://chatgpt.com/codex/tasks/task_e_68625af286cc832282341c09bbe5bbf2